### PR TITLE
Remove argocd workspace from seed and seed-* pipelines

### DIFF
--- a/charts/datacenter/pipelines/templates/pipelines/seed-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/seed-iot-anomaly-detection.yaml
@@ -7,7 +7,6 @@ spec:
   - name: gitrepos
   - name: config
   - name: github-secret
-  - name: argocd-env-secret
   - name: quay-secret
   - name: build-artifacts
 

--- a/charts/datacenter/pipelines/templates/pipelines/seed-iot-consumer.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/seed-iot-consumer.yaml
@@ -4,10 +4,9 @@ metadata:
   name: seed-iot-consumer
 spec:
   workspaces:
-  - name: gitrepos 
+  - name: gitrepos
   - name: config
   - name: github-secret
-  - name: argocd-env-secret
   - name: quay-secret
   - name: build-artifacts
 

--- a/charts/datacenter/pipelines/templates/pipelines/seed-iot-frontend.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/seed-iot-frontend.yaml
@@ -4,10 +4,9 @@ metadata:
   name: seed-iot-frontend
 spec:
   workspaces:
-  - name: gitrepos 
+  - name: gitrepos
   - name: config
   - name: github-secret
-  - name: argocd-env-secret
   - name: quay-secret
   - name: build-artifacts
 

--- a/charts/datacenter/pipelines/templates/pipelines/seed-iot-software-sensor.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/seed-iot-software-sensor.yaml
@@ -4,10 +4,9 @@ metadata:
   name: seed-iot-software-sensor
 spec:
   workspaces:
-  - name: gitrepos 
+  - name: gitrepos
   - name: config
   - name: github-secret
-  - name: argocd-env-secret
   - name: quay-secret
   - name: build-artifacts
 

--- a/charts/datacenter/pipelines/templates/pipelines/seed.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/seed.yaml
@@ -7,7 +7,6 @@ spec:
   - name: gitrepos
   - name: config
   - name: github-secret
-  - name: argocd-env-secret
   - name: quay-secret
   - name: build-artifacts
   tasks:
@@ -28,8 +27,6 @@ spec:
       - name=config,config=environment
       - --workspace
       - name=github-secret,secret=github
-      - --workspace
-      - name=argocd-env-secret,secret=argocd-env
       - --workspace
       - name=quay-secret,secret=quay-build-secret
       - --workspace
@@ -56,8 +53,6 @@ spec:
       - --workspace
       - name=github-secret,secret=github
       - --workspace
-      - name=argocd-env-secret,secret=argocd-env
-      - --workspace
       - name=quay-secret,secret=quay-build-secret
       - --workspace
       - name=build-artifacts,claimName=build-artifacts-rwo
@@ -83,8 +78,6 @@ spec:
       - --workspace
       - name=github-secret,secret=github
       - --workspace
-      - name=argocd-env-secret,secret=argocd-env
-      - --workspace
       - name=quay-secret,secret=quay-build-secret
       - --workspace
       - name=build-artifacts,claimName=build-artifacts-rwo
@@ -109,8 +102,6 @@ spec:
       - name=config,config=environment
       - --workspace
       - name=github-secret,secret=github
-      - --workspace
-      - name=argocd-env-secret,secret=argocd-env
       - --workspace
       - name=quay-secret,secret=quay-build-secret
       - --workspace


### PR DESCRIPTION
ArgoCD secret apparently is not required for seed and the seed sub-pipelines, so remove it.