### PR TITLE
Pipeline improvements: Separate build-and-test and seed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,6 @@ sleep-seed:
 
 seed:
 	oc create -f charts/datacenter/pipelines/extra/seed-run.yaml
+
+build-and-test:
+	oc create -f charts/datacenter/pipelines/extra/build-and-test-run.yaml

--- a/charts/datacenter/pipelines/extra/build-and-test-run.yaml
+++ b/charts/datacenter/pipelines/extra/build-and-test-run.yaml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: build-and-test-run-
+  namespace: manuela-ci
+  labels:
+    argocd.argoproj.io/instance: pipelines-manufacturing-edge-ai-ml-datacenter
+    tekton.dev/pipeline: build-and-test
+spec:
+  params:
+    - name: S2I_BUILDER_IMAGE
+      value: registry.access.redhat.com/rhscl/nodejs-10-rhel7
+    - name: LOCAL_IMAGE
+      value: >-
+        image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
+    - name: PATH_CONTEXT
+      value: components/iot-consumer
+    - name: COMPONENT_NAME
+      value: iot-consumer
+    - name: CONFIGMAP_PREFIX
+      value: IOT_CONSUMER
+    - name: CHAINED_BUILD_DOCKERFILE
+      value: ''
+    - name: DEV_REVISION
+      value: main
+    - name: OPS_REVISION
+      value: main
+  pipelineRef:
+    name: build-and-test
+  serviceAccountName: pipeline
+  timeout: 1h0m0s
+  workspaces:
+    - name: gitrepos
+      persistentVolumeClaim:
+        claimName: gitrepos
+    - configMap:
+        name: environment
+      name: config
+    - name: github-secret
+      secret:
+        secretName: github
+    - name: argocd-env-secret
+      secret:
+        secretName: argocd-env
+    - name: build-artifacts
+      persistentVolumeClaim:
+        claimName: build-artifacts-rwo
+    - name: quay-secret
+      secret:
+        secretName: quay-build-secret

--- a/charts/datacenter/pipelines/extra/build-and-test-run.yaml
+++ b/charts/datacenter/pipelines/extra/build-and-test-run.yaml
@@ -32,7 +32,7 @@ spec:
   workspaces:
     - name: gitrepos
       persistentVolumeClaim:
-        claimName: gitrepos
+        claimName: gitrepos-rwo
     - configMap:
         name: environment
       name: config

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test.yaml
@@ -67,6 +67,8 @@ spec:
       - --nocolour
 
   - name: build-iot-anomaly-detection
+    runAfter:
+      - build-images
     taskRef:
       name: tkn
     params:

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test.yaml
@@ -66,9 +66,103 @@ spec:
       - --showlog
       - --nocolour
 
+  - name: build-iot-anomaly-detection
+    taskRef:
+      name: tkn
+    params:
+    - name: ARGS
+      value:
+      - pipeline
+      - start
+      - build-iot-anomaly-detection
+      - --workspace
+      - name=gitrepos,claimName=gitrepos-rwo
+      - --workspace
+      - name=config,config=environment
+      - --workspace
+      - name=github-secret,secret=github
+      - --workspace
+      - name=quay-secret,secret=quay-build-secret
+      - --workspace
+      - name=build-artifacts,claimName=build-artifacts-rwo
+      - --showlog
+      - --nocolour
+
+  - name: build-iot-consumer
+    runAfter:
+      - build-iot-anomaly-detection
+    taskRef:
+      name: tkn
+    params:
+    - name: ARGS
+      value:
+      - pipeline
+      - start
+      - build-iot-consumer
+      - --workspace
+      - name=gitrepos,claimName=gitrepos-rwo
+      - --workspace
+      - name=config,config=environment
+      - --workspace
+      - name=github-secret,secret=github
+      - --workspace
+      - name=quay-secret,secret=quay-build-secret
+      - --workspace
+      - name=build-artifacts,claimName=build-artifacts-rwo
+      - --showlog
+      - --nocolour
+
+  - name: build-iot-frontend
+    runAfter:
+      - build-iot-consumer
+    taskRef:
+      name: tkn
+    params:
+    - name: ARGS
+      value:
+      - pipeline
+      - start
+      - build-iot-frontend
+      - --workspace
+      - name=gitrepos,claimName=gitrepos-rwo
+      - --workspace
+      - name=config,config=environment
+      - --workspace
+      - name=github-secret,secret=github
+      - --workspace
+      - name=quay-secret,secret=quay-build-secret
+      - --workspace
+      - name=build-artifacts,claimName=build-artifacts-rwo
+      - --showlog
+      - --nocolour
+
+  - name: build-iot-software-sensor
+    runAfter:
+      - build-iot-frontend
+    taskRef:
+      name: tkn
+    params:
+    - name: ARGS
+      value:
+      - pipeline
+      - start
+      - build-iot-software-sensor
+      - --workspace
+      - name=gitrepos,claimName=gitrepos-rwo
+      - --workspace
+      - name=config,config=environment
+      - --workspace
+      - name=github-secret,secret=github
+      - --workspace
+      - name=quay-secret,secret=quay-build-secret
+      - --workspace
+      - name=build-artifacts,claimName=build-artifacts-rwo
+      - --showlog
+      - --nocolour
+  
   - name: git-clone-dev
     runAfter:
-      - build-images
+      - build-iot-software-sensor
     taskRef:
       name: git-clone-with-tags
     workspaces:

--- a/charts/datacenter/pipelines/templates/pipelines/build-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-iot-anomaly-detection.yaml
@@ -1,0 +1,166 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-iot-anomaly-detection
+spec:
+  workspaces:
+  - name: gitrepos
+  - name: config
+  - name: github-secret
+  - name: quay-secret
+  - name: build-artifacts
+
+  tasks:
+  - name: git-clone-dev
+    taskRef:
+      name: git-clone-with-tags
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_DEV_REPO_URL
+    - name: revision
+      value: {{ .Values.global.git.dev_revision }}
+    - name: subdirectory
+      value: dev
+    - name: deleteExisting
+      value: "true"
+
+  - name: git-clone-ops
+    taskRef:
+      name: git-clone-with-tags
+    runAfter:
+    - git-clone-dev
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_OPS_REPO_TEST_URL
+    - name: revision
+      value: {{ .Values.global.targetRevision }}
+    - name: subdirectory
+      value: ops
+    - name: deleteExisting
+      value: "true"
+
+  - name: bump-build-version-iot-anomaly
+    taskRef:
+      name: bumpversion
+    runAfter:
+    - git-clone-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    params:
+    - name: component_name
+      value: iot-anomaly
+    - name: version_file_path
+      value: components/iot-anomaly-detection/VERSION
+
+  - name: s2i-build-iot-anomaly
+    taskRef:
+      name: s2i
+    runAfter:
+    - bump-build-version-iot-anomaly
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: build-artifacts
+      workspace: build-artifacts
+    params:
+    - name: TLSVERIFY
+      value: "false"
+    - name: PATH_CONTEXT
+      value: components/iot-anomaly-detection
+    - name: BUILDER_IMAGE
+      value: registry.access.redhat.com/rhscl/python-36-rhel7
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
+    - name: OUTPUT_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
+
+  - name: copy-image-to-remote-registry-iot-anomaly
+    taskRef:
+      name: skopeo-copy
+    runAfter: 
+    - s2i-build-iot-anomaly
+    workspaces:
+    - name: config
+      workspace: config
+    - name: pushsecret
+      workspace: quay-secret
+    params:
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
+    - name: SOURCE_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
+    - name: TARGET_IMAGE_CONFIGMAPKEY
+      value: IOT_ANOMALY_IMAGE
+
+  - name: push-dev-tag
+    taskRef:
+      name: github-push
+    runAfter:
+    - copy-image-to-remote-registry-iot-anomaly
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: PUSH_FLAGS
+      value: --tags
+
+  - name: modify-ops-test-iot-anomaly
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - push-dev-tag
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_ANOMALY
+    - name: ENVIRONMENT
+      value: TEST
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: commit-ops
+    taskRef:
+      name: git-commit
+    runAfter:
+    - modify-ops-test-iot-anomaly
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: subdirectory
+      value: ops
+
+  - name: push-ops
+    taskRef:
+      name: github-push
+    runAfter:
+    - commit-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: subdirectory
+      value: ops

--- a/charts/datacenter/pipelines/templates/pipelines/build-iot-consumer.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-iot-consumer.yaml
@@ -1,0 +1,167 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-iot-consumer
+spec:
+  workspaces:
+  - name: gitrepos
+  - name: config
+  - name: github-secret
+  - name: quay-secret
+  - name: build-artifacts
+
+  tasks:
+  - name: git-clone-dev
+    taskRef:
+      name: git-clone-with-tags
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_DEV_REPO_URL
+    - name: revision
+      value: {{ .Values.global.git.dev_revision }}
+    - name: subdirectory
+      value: dev
+    - name: deleteExisting
+      value: "true"
+
+  - name: git-clone-ops
+    taskRef:
+      name: git-clone-with-tags
+    runAfter:
+    - git-clone-dev
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_OPS_REPO_TEST_URL
+    - name: revision
+      value: {{ .Values.global.targetRevision }}
+    - name: subdirectory
+      value: ops
+    - name: deleteExisting
+      value: "true"
+
+  - name: bump-build-version-iot-consumer
+    taskRef:
+      name: bumpversion
+    runAfter:
+    - git-clone-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    params:
+    - name: component_name
+      value: iot-consumer
+    - name: version_file_path
+      value: components/iot-consumer/VERSION
+
+  - name: s2i-build-iot-consumer
+    taskRef:
+      name: s2i
+    runAfter:
+    - bump-build-version-iot-consumer 
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: build-artifacts
+      workspace: build-artifacts
+    params:
+    - name: TLSVERIFY
+      value: "false"
+    - name: PATH_CONTEXT
+      value: components/iot-consumer
+    - name: BUILDER_IMAGE
+      value: registry.access.redhat.com/rhscl/nodejs-10-rhel7
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-consumer.results.image-tag)
+    - name: OUTPUT_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
+
+  - name: copy-image-to-remote-registry-iot-consumer
+    taskRef:
+      name: skopeo-copy
+    runAfter: 
+    - s2i-build-iot-consumer
+    workspaces:
+    - name: config
+      workspace: config
+    - name: pushsecret
+      workspace: quay-secret
+    params:
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-consumer.results.image-tag)
+    - name: SOURCE_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
+    - name: TARGET_IMAGE_CONFIGMAPKEY
+      value: IOT_CONSUMER_IMAGE
+
+  - name: push-dev-tag
+    taskRef:
+      name: github-push
+    runAfter:
+    - copy-image-to-remote-registry-iot-consumer
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: PUSH_FLAGS
+      value: --tags
+
+
+  - name: modify-ops-test-iot-consumer
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - push-dev-tag
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_CONSUMER
+    - name: ENVIRONMENT
+      value: TEST
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-consumer.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: commit-ops
+    taskRef:
+      name: git-commit
+    runAfter:
+    - modify-ops-test-iot-consumer
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config 
+      workspace: config
+    params:
+    - name: subdirectory
+      value: ops
+
+  - name: push-ops
+    taskRef:
+      name: github-push
+    runAfter:
+    - commit-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: subdirectory
+      value: ops

--- a/charts/datacenter/pipelines/templates/pipelines/build-iot-frontend.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-iot-frontend.yaml
@@ -1,0 +1,169 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-iot-frontend
+spec:
+  workspaces:
+  - name: gitrepos
+  - name: config
+  - name: github-secret
+  - name: quay-secret
+  - name: build-artifacts
+
+  tasks:
+  - name: git-clone-dev
+    taskRef:
+      name: git-clone-with-tags
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_DEV_REPO_URL
+    - name: revision
+      value: {{ .Values.global.git.dev_revision }}
+    - name: subdirectory
+      value: dev
+    - name: deleteExisting
+      value: "true"
+
+  - name: git-clone-ops
+    taskRef:
+      name: git-clone-with-tags
+    runAfter:
+    - git-clone-dev
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_OPS_REPO_TEST_URL
+    - name: revision
+      value: {{ .Values.global.targetRevision }}
+    - name: subdirectory
+      value: ops
+    - name: deleteExisting
+      value: "true"
+
+  - name: bump-build-version-iot-frontend
+    taskRef:
+      name: bumpversion
+    runAfter:
+    - git-clone-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    params:
+    - name: component_name
+      value: iot-frontend
+    - name: version_file_path
+      value: components/iot-frontend/VERSION
+
+  - name: s2i-build-iot-frontend
+    taskRef:
+      name: s2i
+    runAfter:
+    - bump-build-version-iot-frontend
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: build-artifacts
+      workspace: build-artifacts
+    params:
+    - name: TLSVERIFY
+      value: "false"
+    - name: PATH_CONTEXT
+      value: components/iot-frontend
+    - name: BUILDER_IMAGE
+      value: nodeshift/ubi8-s2i-web-app
+    - name: CHAINED_BUILD_DOCKERFILE
+      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
+    - name: OUTPUT_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
+
+  - name: copy-image-to-remote-registry-iot-frontend
+    taskRef:
+      name: skopeo-copy
+    runAfter: 
+    - s2i-build-iot-frontend
+    workspaces:
+    - name: config
+      workspace: config
+    - name: pushsecret
+      workspace: quay-secret
+    params:
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
+    - name: SOURCE_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/line-dashboard
+    - name: TARGET_IMAGE_CONFIGMAPKEY
+      value: IOT_FRONTEND_IMAGE
+
+  - name: push-dev-tag
+    taskRef:
+      name: github-push
+    runAfter:
+    - copy-image-to-remote-registry-iot-frontend
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: PUSH_FLAGS
+      value: --tags
+
+
+  - name: modify-ops-test-iot-frontend
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - push-dev-tag
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_FRONTEND
+    - name: ENVIRONMENT
+      value: TEST
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: commit-ops
+    taskRef:
+      name: git-commit
+    runAfter:
+    - modify-ops-test-iot-frontend
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config 
+      workspace: config
+    params:
+    - name: subdirectory
+      value: ops
+
+  - name: push-ops
+    taskRef:
+      name: github-push
+    runAfter:
+    - commit-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: subdirectory
+      value: ops

--- a/charts/datacenter/pipelines/templates/pipelines/build-iot-software-sensor.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-iot-software-sensor.yaml
@@ -1,0 +1,166 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-iot-software-sensor
+spec:
+  workspaces:
+  - name: gitrepos
+  - name: config
+  - name: github-secret
+  - name: quay-secret
+  - name: build-artifacts
+
+  tasks:
+  - name: git-clone-dev
+    taskRef:
+      name: git-clone-with-tags
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_DEV_REPO_URL
+    - name: revision
+      value: {{ .Values.global.git.dev_revision }}
+    - name: subdirectory
+      value: dev
+    - name: deleteExisting
+      value: "true"
+
+  - name: git-clone-ops
+    taskRef:
+      name: git-clone-with-tags
+    runAfter:
+    - git-clone-dev
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_OPS_REPO_TEST_URL
+    - name: revision
+      value: {{ .Values.global.targetRevision }}
+    - name: subdirectory
+      value: ops
+    - name: deleteExisting
+      value: "true"
+
+  - name: bump-build-version-iot-software-sensor
+    taskRef:
+      name: bumpversion
+    runAfter:
+    - git-clone-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    params:
+    - name: component_name
+      value: iot-swsensor
+    - name: version_file_path
+      value: components/iot-software-sensor/VERSION
+
+  - name: s2i-build-iot-software-sensor
+    taskRef:
+      name: s2i
+    runAfter:
+    - bump-build-version-iot-software-sensor
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: build-artifacts
+      workspace: build-artifacts
+    params:
+    - name: TLSVERIFY
+      value: "false"
+    - name: PATH_CONTEXT
+      value: components/iot-software-sensor
+    - name: BUILDER_IMAGE
+      value: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-software-sensor.results.image-tag)
+    - name: OUTPUT_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
+
+  - name: copy-image-to-remote-registry-iot-software-sensor
+    taskRef:
+      name: skopeo-copy
+    runAfter: 
+    - s2i-build-iot-software-sensor
+    workspaces:
+    - name: config
+      workspace: config
+    - name: pushsecret
+      workspace: quay-secret
+    params:
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-software-sensor.results.image-tag)
+    - name: SOURCE_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/machine-sensor
+    - name: TARGET_IMAGE_CONFIGMAPKEY
+      value: IOT_SWSENSOR_IMAGE
+
+  - name: push-dev-tag
+    taskRef:
+      name: github-push
+    runAfter:
+    - copy-image-to-remote-registry-iot-software-sensor 
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: PUSH_FLAGS
+      value: --tags
+
+  - name: modify-ops-test-iot-software-sensor
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - push-dev-tag
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_SWSENSOR
+    - name: ENVIRONMENT
+      value: TEST
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-software-sensor.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: commit-ops
+    taskRef:
+      name: git-commit
+    runAfter:
+    - modify-ops-test-iot-software-sensor
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config 
+      workspace: config
+    params:
+    - name: subdirectory
+      value: ops
+
+  - name: push-ops
+    taskRef:
+      name: github-push
+    runAfter:
+    - commit-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: subdirectory
+      value: ops

--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -32,7 +32,7 @@ site:
     csv: opendatahub-operator.v1.1.0
 
   - name: openshift-pipelines-operator-rh
-    csv: redhat-openshift-pipelines.v1.5.1
+    csv: redhat-openshift-pipelines.v1.5.2
 
   # TODO: Allow namespace to be a list
   - name: amq-streams


### PR DESCRIPTION
1) build-and-test pipeline now runs individual "build" pipelines before argocd sync and test
2) top-level Makefile now has a build-and-test target to kick off a build-and-test pipeline run