### PR TITLE
Fix routes perpetually out of sync in argo issue in manuela-tst-all

### DIFF
--- a/charts/datacenter/manuela-tst/templates/anomaly-detection/anomaly-detection-is.yaml
+++ b/charts/datacenter/manuela-tst/templates/anomaly-detection/anomaly-detection-is.yaml
@@ -1,6 +1,8 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
+  labels:
+    application: anomaly-detection
   name: anomaly-detection
 spec:
   lookupPolicy:

--- a/charts/datacenter/manuela-tst/templates/anomaly-detection/anomaly-detection-is.yaml
+++ b/charts/datacenter/manuela-tst/templates/anomaly-detection/anomaly-detection-is.yaml
@@ -1,8 +1,6 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  labels:
-    application: anomaly-detection
   name: anomaly-detection
 spec:
   lookupPolicy:

--- a/charts/datacenter/manuela-tst/templates/line-dashboard/line-dashboard-route.yaml
+++ b/charts/datacenter/manuela-tst/templates/line-dashboard/line-dashboard-route.yaml
@@ -13,5 +13,3 @@ spec:
     name: line-dashboard
     weight: 100
   wildcardPolicy: None
-status:
-  ingress: []

--- a/charts/datacenter/manuela-tst/templates/messaging/messaging-route.yaml
+++ b/charts/datacenter/manuela-tst/templates/messaging/messaging-route.yaml
@@ -13,5 +13,3 @@ spec:
     name: messaging
     weight: 100
   wildcardPolicy: None
-status:
-  ingress: []


### PR DESCRIPTION
Remove unneeded status.ingress blocks from yaml files that describe routes.
Revert a previous change that attempted to do something similar in anomaly-detection imagestream but was unsuccessful